### PR TITLE
Remove some side effects from Reclaimer TE methods

### DIFF
--- a/src/main/java/com/yungnickyoung/minecraft/betterportals/client/ReclaimerTileEntityRenderer.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterportals/client/ReclaimerTileEntityRenderer.java
@@ -62,6 +62,7 @@ public class ReclaimerTileEntityRenderer extends TileEntityRenderer<ReclaimerTil
 
     private static void renderBeam(ReclaimerTileEntity tileEntity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer) {
         long time = tileEntity.getWorld().getGameTime();
+        boolean isPowered = tileEntity.isPowered();
         List<ReclaimerTileEntity.BeamPiece> beamSegments = tileEntity.getBeamPieces();
         float yOffset = 0.5f;
 
@@ -77,9 +78,9 @@ public class ReclaimerTileEntityRenderer extends TileEntityRenderer<ReclaimerTil
                 yOffset,
                 beamSegment.getHeight(),
                 beamSegment.getColors(),
-                tileEntity.isPowered() ? .4f : .1f, // Powered beam has larger beam radius
-                tileEntity.isPowered() ? .6f : .15f, // Powered beam has larger glow radius
-                tileEntity.isPowered() ? 2.5f : .5f // Powered beam spins faster
+                isPowered ? .4f : .1f, // Powered beam has larger beam radius
+                isPowered ? .6f : .15f, // Powered beam has larger glow radius
+                isPowered ? 2.5f : .5f // Powered beam spins faster
             );
             yOffset += beamSegment.getHeight();
         }

--- a/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
@@ -51,11 +51,10 @@ public class ReclaimerTileEntity extends TileEntity implements ITickableTileEnti
         }
 
         // Play ambient sound if powered
-        if (this.world.getBlockState(this.pos).getBlock() == BPModBlocks.RECLAIMER_BLOCK) {
-            if (this.world.getBlockState(this.pos).get(ReclaimerBlock.POWERED)) {
-                if (world.getGameTime() % 80L == 0L) {
-                    world.playSound(null, pos, SoundEvents.BLOCK_BEACON_AMBIENT, SoundCategory.BLOCKS, 1f, 1f);
-                }
+        boolean isPowered = this.isPowered();
+        if (isPowered) {
+            if (world.getGameTime() % 80L == 0L) {
+                world.playSound(null, pos, SoundEvents.BLOCK_BEACON_AMBIENT, SoundCategory.BLOCKS, 1f, 1f);
             }
         }
 
@@ -137,14 +136,13 @@ public class ReclaimerTileEntity extends TileEntity implements ITickableTileEnti
             this.beamSegments = this.tempBeamSegments;
         }
 
-        boolean isPowered = this.isPowered();
         int floatAmp = isPowered ? 5 : 2; // Powered beams levitate entities more quickly
 
         // Float up items in beam
         if (!this.world.isRemote) {
             List<ItemEntity> itemsInBeam = getItemsInBeam();
             for (ItemEntity entity : itemsInBeam) {
-                double floatSpeed = isPowered() ? .2 : .08;
+                double floatSpeed = isPowered ? .2 : .08;
                 entity.setMotion(entity.getMotion().getX() / 1.5, floatSpeed, entity.getMotion().getZ() / 1.5);
             }
         }

--- a/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
@@ -214,8 +214,11 @@ public class ReclaimerTileEntity extends TileEntity implements ITickableTileEnti
     }
 
     public boolean isPowered() {
-        if (this.world != null && this.world.getBlockState(this.pos).getBlock() == BPModBlocks.RECLAIMER_BLOCK) {
-            return this.world.getBlockState(this.pos).get(ReclaimerBlock.POWERED);
+        if (this.world != null) {
+            BlockState state = this.world.getBlockState(this.pos);
+            if (state.getBlock() == BPModBlocks.RECLAIMER_BLOCK && state.hasProperty(ReclaimerBlock.POWERED)) {
+                return state.get(ReclaimerBlock.POWERED);
+            }
         }
         return false;
     }

--- a/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterportals/tileentity/ReclaimerTileEntity.java
@@ -117,7 +117,7 @@ public class ReclaimerTileEntity extends TileEntity implements ITickableTileEnti
                         this.tempBeamSegments.add(beamSegment);
                     }
                 }
-            } else {
+            } else if (beamSegment != null) {
                 beamSegment.incrementHeight();
             }
 


### PR DESCRIPTION
- Fixed a rare crash where even if the block is a ReclaimerBlock the
  client might be getting the state of an air block and causes a crash
  on the client